### PR TITLE
Add GitHub Skills activity (quick add)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Hands-on lessons on Git, GitHub workflows, and collaboration best practices; prepares students for GitHub certifications",
+        "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
Adds the `GitHub Skills` extracurricular activity so students can register. This is a small, urgent fix referenced by issue #6.\n\nFixes: #6